### PR TITLE
Range add step

### DIFF
--- a/range.js
+++ b/range.js
@@ -1,9 +1,13 @@
+"use strict";
+
 var debug = require("debug")("funcalicious:range");
 var sign = require("./sign");
 
 module.exports = range.range = range;
 
-function range(from, to) {
+function range(from, to, step) {
+    var steps;
+
     if (undefined == to) {
         to = from;
         from = 0;
@@ -11,11 +15,26 @@ function range(from, to) {
 
     from = Math.round(from);
     to = Math.round(to);
-    step = sign(to - from);
 
-    debug("from %d to %d (%d) step %d", from, to, Math.abs(to - from), step);
+    if (undefined == step) {
+        step = sign(to - from);
+    }
 
-    return Array.apply(Array, Array(Math.abs(to - from))).
+    // Make sure range direction matches step sign
+    if (sign(to - from) !== sign(step)) {
+        throw new Error("Step does not match range direction");
+    }
+
+    steps = Math.abs(to - from) / Math.abs(step);
+
+    // Odd number of steps is not supported
+    if (Math.round(steps) !== steps) {
+        throw new Error("Invalid step increase for range");
+    }
+
+    debug("from %d to %d (%d) step %d = %d steps", from, to, Math.abs(to - from), step, steps);
+
+    return Array.apply(Array, Array(steps)).
         map(function (_, i) {
             return from + i * step;
         });

--- a/test/range.js
+++ b/test/range.js
@@ -41,4 +41,38 @@ test("range", function (t) {
         t.equal(r.shift(), 10, "head check");
         t.equal(r.pop(), 1, "tail check");
     });
+
+    t.test("custom step", function (t) {
+        t.plan(3);
+
+        var r = range(0, 10, 2);
+
+        t.equal(5, r.length, "length check");
+        t.equal(r.pop(), 8, "tail check");
+        t.equal(r.shift(), 0, "head check");
+    });
+
+    t.test("custom negative step", function (t) {
+        t.plan(3);
+
+        var r = range(15, 0, -3);
+
+        t.equal(5, r.length, "length check");
+        t.equal(r.pop(), 3, "tail check");
+        t.equal(r.shift(), 15, "head check");
+    });
+
+    t.test("invalid step sign throws", function (t) {
+        t.plan(1);
+        t.throws(function () {
+            range(15, 0, 3);
+        });
+    });
+
+    t.test("invalid step size throws", function (t) {
+        t.plan(1);
+        t.throws(function () {
+            range(0, 10, 3);
+        });
+    });
 });


### PR DESCRIPTION
- Adds `step` argument. 
- Fixes leaking `step` variable. 
- Adds strict check for non-matching step size
- Adds strict check for non-matching step direction
